### PR TITLE
Add in memory PEM support for TLSSetting

### DIFF
--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -240,7 +240,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		host     component.Host
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: GRPCClientSettings{
 				Headers:     nil,
 				Endpoint:    "",
@@ -376,7 +376,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist: open /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",
@@ -404,7 +404,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: failed to load client CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load client CA CertPool: failed to load cert /doesnt/exist:",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",

--- a/config/configgrpc/configgrpc_test.go
+++ b/config/configgrpc/configgrpc_test.go
@@ -240,7 +240,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 		host     component.Host
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist:",
 			settings: GRPCClientSettings{
 				Headers:     nil,
 				Endpoint:    "",
@@ -256,7 +256,7 @@ func TestGRPCClientSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: GRPCClientSettings{
 				Headers:     nil,
 				Endpoint:    "",
@@ -376,7 +376,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist: open /doesnt/exist:",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",
@@ -390,7 +390,7 @@ func TestGRPCServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: GRPCServerSettings{
 				NetAddr: confignet.NetAddr{
 					Endpoint:  "127.0.0.1:1234",

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -217,7 +217,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: HTTPClientSettings{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
@@ -353,7 +353,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load cert /doesnt/exist:",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
@@ -375,7 +375,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: failed to load client CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load client CA CertPool: failed to load cert /doesnt/exist:",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{

--- a/config/confighttp/confighttp_test.go
+++ b/config/confighttp/confighttp_test.go
@@ -217,7 +217,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist:",
 			settings: HTTPClientSettings{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
@@ -230,7 +230,7 @@ func TestHTTPClientSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: HTTPClientSettings{
 				Endpoint: "",
 				TLSSetting: configtls.TLSClientSetting{
@@ -353,7 +353,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 		err      string
 	}{
 		{
-			err: "^failed to load TLS config: failed to load CA CertPool: failed to load CA /doesnt/exist:",
+			err: "^failed to load TLS config: failed to load CA CertPool File: failed to load CA /doesnt/exist:",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{
@@ -364,7 +364,7 @@ func TestHTTPServerSettingsError(t *testing.T) {
 			},
 		},
 		{
-			err: "^failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither",
+			err: "^failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
 			settings: HTTPServerSettings{
 				Endpoint: "localhost:0",
 				TLSSetting: &configtls.TLSServerSetting{

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -117,14 +117,14 @@ type certReloader struct {
 	tls        TLSSetting
 }
 
-func (c TLSSetting) newCertReloader(reloadInterval time.Duration) (*certReloader, error) {
+func (c TLSSetting) newCertReloader() (*certReloader, error) {
 	cert, err := c.loadCertificate()
 	if err != nil {
 		return nil, err
 	}
 	return &certReloader{
 		tls:        c,
-		nextReload: time.Now().Add(reloadInterval),
+		nextReload: time.Now().Add(c.ReloadInterval),
 		cert:       &cert,
 	}, nil
 }
@@ -164,7 +164,7 @@ func (c TLSSetting) loadTLSConfig() (*tls.Config, error) {
 	var getClientCertificate func(*tls.CertificateRequestInfo) (*tls.Certificate, error)
 
 	var certReloader *certReloader
-	certReloader, err = c.newCertReloader(c.ReloadInterval)
+	certReloader, err = c.newCertReloader()
 	if err != nil {
 		return nil, fmt.Errorf("failed to load TLS cert and key: %w", err)
 	}
@@ -251,7 +251,6 @@ func (c TLSSetting) loadCertificate() (tls.Certificate, error) {
 
 	var certPem, keyPem []byte
 	var err error
-
 	if c.hasCertFile() {
 		certPem, err = os.ReadFile(c.CertFile)
 		if err != nil {

--- a/config/configtls/configtls.go
+++ b/config/configtls/configtls.go
@@ -292,7 +292,7 @@ func (c TLSSetting) loadCertificate() (tls.Certificate, error) {
 
 // LoadTLSConfig loads the TLS configuration.
 func (c TLSClientSetting) LoadTLSConfig() (*tls.Config, error) {
-	if c.Insecure && c.CAFile == "" {
+	if c.Insecure && c.CAFile == "" && len(c.CAPem) == 0 {
 		return nil, nil
 	}
 

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +50,7 @@ func TestOptionsToConfig(t *testing.T) {
 		{
 			name:        "should fail with invalid CA file content",
 			options:     TLSSetting{CAFile: filepath.Join("testdata", "testCA-bad.txt")},
-			expectError: "failed to parse CA",
+			expectError: "failed to parse cert",
 		},
 		{
 			name: "should load valid TLS  settings",
@@ -107,7 +106,7 @@ func TestOptionsToConfig(t *testing.T) {
 			options: TLSSetting{
 				CAFile: filepath.Join("testdata", "testCA-bad.txt"),
 			},
-			expectError: "failed to parse CA",
+			expectError: "failed to parse cert",
 		},
 		{
 			name: "should pass with valid CA pool",
@@ -145,7 +144,7 @@ func TestOptionsToConfig(t *testing.T) {
 		{
 			name:        "should fail with invalid CA PEM",
 			options:     TLSSetting{CAPem: readFilePanics("testdata/testCA-bad.txt")},
-			expectError: "failed to parse CA",
+			expectError: "failed to parse cert",
 		},
 		{
 			name: "should fail CA file and PEM both provided",
@@ -169,7 +168,6 @@ func TestOptionsToConfig(t *testing.T) {
 				CertFile: "testdata/server-1.crt",
 				KeyPem:   readFilePanics("testdata/server-1.key"),
 			},
-			expectError: "failed to load TLS cert file and key PEM: both must be provided as a file or both as a PEM",
 		},
 		{
 			name: "should fail Cert PEM and Key File provided",
@@ -177,7 +175,6 @@ func TestOptionsToConfig(t *testing.T) {
 				CertPem: readFilePanics("testdata/server-1.crt"),
 				KeyFile: "testdata/server-1.key",
 			},
-			expectError: "failed to load TLS cert PEM and key file: both must be provided as a file or both as a PEM",
 		},
 		{
 			name: "should fail Key file and PEM both provided",
@@ -246,7 +243,7 @@ func TestOptionsToConfig(t *testing.T) {
 }
 
 func readFilePanics(filePath string) []byte {
-	fileContents, err := ioutil.ReadFile(filepath.Clean(filePath))
+	fileContents, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		panic(fmt.Sprintf("failed to read file %s: %v", filePath, err))
 	}
@@ -373,7 +370,7 @@ func TestCertificateReload(t *testing.T) {
 			cert2:          "testCA-bad.txt",
 			key2:           "client-2.key",
 			dns1:           "example1",
-			errText:        "failed to load TLS cert and key: tls: failed to find any PEM data in certificate input",
+			errText:        "failed to load TLS cert and key: failed to load TLS cert and key PEMs: tls: failed to find any PEM data in certificate input",
 		},
 	}
 

--- a/config/configtls/configtls_test.go
+++ b/config/configtls/configtls_test.go
@@ -135,12 +135,32 @@ func TestOptionsToConfig(t *testing.T) {
 			},
 			expectError: "invalid TLS max_",
 		},
-
 		{
 			name:    "should load custom CA PEM",
 			options: TLSSetting{CAPem: readFilePanics("testdata/ca-1.crt")},
 		},
-
+		{
+			name: "should load valid TLS settings with PEMs",
+			options: TLSSetting{
+				CAPem:   readFilePanics("testdata/ca-1.crt"),
+				CertPem: readFilePanics("testdata/server-1.crt"),
+				KeyPem:  readFilePanics("testdata/server-1.key"),
+			},
+		},
+		{
+			name: "mix Cert file and Key PEM provided",
+			options: TLSSetting{
+				CertFile: "testdata/server-1.crt",
+				KeyPem:   readFilePanics("testdata/server-1.key"),
+			},
+		},
+		{
+			name: "mix Cert PEM and Key File provided",
+			options: TLSSetting{
+				CertPem: readFilePanics("testdata/server-1.crt"),
+				KeyFile: "testdata/server-1.key",
+			},
+		},
 		{
 			name:        "should fail with invalid CA PEM",
 			options:     TLSSetting{CAPem: readFilePanics("testdata/testCA-bad.txt")},
@@ -152,37 +172,25 @@ func TestOptionsToConfig(t *testing.T) {
 				CAFile: "testdata/ca-1.crt",
 				CAPem:  readFilePanics("testdata/ca-1.crt"),
 			},
-			expectError: "failed to load CA CertPool: CA File and PEM cannot both be provided",
+			expectError: "CA File and PEM cannot both be provided",
 		},
 		{
 			name: "should fail Cert file and PEM both provided",
 			options: TLSSetting{
 				CertFile: "testdata/server-1.crt",
 				CertPem:  readFilePanics("testdata/server-1.crt"),
+				KeyFile:  "testdata/server-1.key",
 			},
-			expectError: "for auth via TLS, either both certificate and key must be supplied, or neither",
-		},
-		{
-			name: "should fail Cert file and Key PEM provided",
-			options: TLSSetting{
-				CertFile: "testdata/server-1.crt",
-				KeyPem:   readFilePanics("testdata/server-1.key"),
-			},
-		},
-		{
-			name: "should fail Cert PEM and Key File provided",
-			options: TLSSetting{
-				CertPem: readFilePanics("testdata/server-1.crt"),
-				KeyFile: "testdata/server-1.key",
-			},
+			expectError: "for auth via TLS, certificate file and PEM cannot both be provided",
 		},
 		{
 			name: "should fail Key file and PEM both provided",
 			options: TLSSetting{
-				KeyFile: "testdata/ca-1.crt",
-				KeyPem:  readFilePanics("testdata/server-1.key"),
+				CertFile: "testdata/server-1.crt",
+				KeyFile:  "testdata/ca-1.crt",
+				KeyPem:   readFilePanics("testdata/server-1.key"),
 			},
-			expectError: "failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither",
+			expectError: "for auth via TLS, key file and PEM cannot both be provided",
 		},
 		{
 			name: "should fail to load valid TLS settings with bad Cert PEM",
@@ -201,14 +209,6 @@ func TestOptionsToConfig(t *testing.T) {
 				KeyPem:  readFilePanics("testdata/testCA-bad.txt"),
 			},
 			expectError: "failed to load TLS cert and key PEMs",
-		},
-		{
-			name: "should load valid TLS settings with PEMs",
-			options: TLSSetting{
-				CAPem:   readFilePanics("testdata/ca-1.crt"),
-				CertPem: readFilePanics("testdata/server-1.crt"),
-				KeyPem:  readFilePanics("testdata/server-1.key"),
-			},
 		},
 		{
 			name: "should fail with missing TLS KeyPem",

--- a/receiver/otlpreceiver/otlp_test.go
+++ b/receiver/otlpreceiver/otlp_test.go
@@ -734,7 +734,7 @@ func TestGRPCInvalidTLSCredentials(t *testing.T) {
 
 	assert.EqualError(t,
 		r.Start(context.Background(), componenttest.NewNopHost()),
-		`failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
+		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither`)
 }
 
 func TestGRPCMaxRecvSize(t *testing.T) {
@@ -801,7 +801,7 @@ func TestHTTPInvalidTLSCredentials(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 	assert.EqualError(t, r.Start(context.Background(), componenttest.NewNopHost()),
-		`failed to load TLS config: for auth via TLS, either both certificate and key must be supplied, or neither`)
+		`failed to load TLS config: failed to load TLS cert and key: for auth via TLS, either both certificate and key must be supplied, or neither`)
 }
 
 func testHTTPMaxRequestBodySizeJSON(t *testing.T, payload []byte, size int, expectedStatusCode int) {


### PR DESCRIPTION
**Description:** In memory PEM support added for TLSSetting so that sources other than a file can be used for certificates.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** Added tests for all new scenarios with in memory PEM

**Documentation:** none