### PR TITLE
Configure service telemetry

### DIFF
--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -84,7 +84,7 @@ func (cm *configProvider) Get(ctx context.Context, factories Factories) (*Config
 	}
 
 	var cfg *configSettings
-	if cfg, err = unmarshal(conf, factories); err != nil {
+	if cfg, err = Unmarshal(conf, factories); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal the configuration: %w", err)
 	}
 

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -29,7 +29,7 @@ type configSettings struct {
 
 // unmarshal the configSettings from a confmap.Conf.
 // After the config is unmarshalled, `Validate()` must be called to validate.
-func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
+func Unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 	// Unmarshal top level sections and validate.
 	cfg := &configSettings{
 		Receivers:  configunmarshaler.NewConfigs(factories.Receivers),

--- a/service/service.go
+++ b/service/service.go
@@ -62,6 +62,8 @@ type Settings struct {
 
 	OtelMetricReader sdkmetric.Reader
 
+	UseExternalMetricsServer bool
+
 	// For testing purpose only.
 	useOtel *bool
 }
@@ -113,7 +115,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		Resource: pcommonRes,
 	}
 
-	if err = srv.telemetryInitializer.init(res, srv.telemetrySettings, cfg.Telemetry, set.AsyncErrorChannel, set.OtelMetricViews, set.OtelMetricReader); err != nil {
+	if err = srv.telemetryInitializer.init(res, srv.telemetrySettings, cfg.Telemetry, set.AsyncErrorChannel, set.OtelMetricViews, set.OtelMetricReader, set.UseExternalMetricsServer); err != nil {
 		return nil, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
 	srv.telemetrySettings.MeterProvider = srv.telemetryInitializer.mp

--- a/service/service.go
+++ b/service/service.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -64,6 +65,8 @@ type Settings struct {
 
 	UseExternalMetricsServer bool
 
+	TracerProvider trace.TracerProvider
+
 	// For testing purpose only.
 	useOtel *bool
 }
@@ -98,7 +101,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		telemetryInitializer: newColTelemetry(useOtel, disableHighCard, extendedConfig),
 	}
 	var err error
-	srv.telemetry, err = telemetry.New(ctx, telemetry.Settings{ZapOptions: set.LoggingOptions}, cfg.Telemetry)
+	srv.telemetry, err = telemetry.New(ctx, telemetry.Settings{ZapOptions: set.LoggingOptions}, cfg.Telemetry, set.TracerProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logger: %w", err)
 	}

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -91,7 +91,7 @@ func newColTelemetry(useOtel bool, disableHighCardinality bool, extendedConfig b
 	}
 }
 
-func (tel *telemetryInitializer) init(res *resource.Resource, settings component.TelemetrySettings, cfg telemetry.Config, asyncErrorChannel chan error) error {
+func (tel *telemetryInitializer) init(res *resource.Resource, settings component.TelemetrySettings, cfg telemetry.Config, asyncErrorChannel chan error, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader) error {
 	if cfg.Metrics.Level == configtelemetry.LevelNone || cfg.Metrics.Address == "" {
 		settings.Logger.Info(
 			"Skipping telemetry setup.",
@@ -109,13 +109,13 @@ func (tel *telemetryInitializer) init(res *resource.Resource, settings component
 		return err
 	}
 
-	return tel.initPrometheus(res, settings.Logger, cfg.Metrics.Address, cfg.Metrics.Level, asyncErrorChannel)
+	return tel.initPrometheus(res, settings.Logger, cfg.Metrics.Address, cfg.Metrics.Level, asyncErrorChannel, otelMetricViews, otelMetricReader)
 }
 
-func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, logger *zap.Logger, address string, level configtelemetry.Level, asyncErrorChannel chan error) error {
+func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, logger *zap.Logger, address string, level configtelemetry.Level, asyncErrorChannel chan error, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader) error {
 	promRegistry := prometheus.NewRegistry()
 	if tel.useOtel {
-		if err := tel.initOpenTelemetry(res, promRegistry); err != nil {
+		if err := tel.initOpenTelemetry(res, promRegistry, otelMetricViews, otelMetricReader); err != nil {
 			return err
 		}
 	} else {
@@ -174,7 +174,7 @@ func (tel *telemetryInitializer) initOpenCensus(level configtelemetry.Level, res
 	return nil
 }
 
-func (tel *telemetryInitializer) initOpenTelemetry(res *resource.Resource, promRegistry *prometheus.Registry) error {
+func (tel *telemetryInitializer) initOpenTelemetry(res *resource.Resource, promRegistry *prometheus.Registry, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader) error {
 	// Initialize the ocRegistry, still used by the process metrics.
 	tel.ocRegistry = ocmetric.NewRegistry()
 	metricproducer.GlobalManager().AddProducer(tel.ocRegistry)
@@ -191,7 +191,6 @@ func (tel *telemetryInitializer) initOpenTelemetry(res *resource.Resource, promR
 	if err != nil {
 		return fmt.Errorf("error creating otel prometheus exporter: %w", err)
 	}
-
 	exporter.RegisterProducer(opencensus.NewMetricProducer())
 	views := batchViews()
 	if tel.disableHighCardinality {
@@ -214,6 +213,8 @@ func (tel *telemetryInitializer) initOpenTelemetry(res *resource.Resource, promR
 		sdkmetric.WithResource(res),
 		sdkmetric.WithReader(exporter),
 		sdkmetric.WithView(views...),
+		sdkmetric.WithReader(otelMetricReader),
+		sdkmetric.WithView(otelMetricViews...),
 	)
 
 	return nil

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -91,8 +91,8 @@ func newColTelemetry(useOtel bool, disableHighCardinality bool, extendedConfig b
 	}
 }
 
-func (tel *telemetryInitializer) init(res *resource.Resource, settings component.TelemetrySettings, cfg telemetry.Config, asyncErrorChannel chan error, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader) error {
-	if cfg.Metrics.Level == configtelemetry.LevelNone || cfg.Metrics.Address == "" {
+func (tel *telemetryInitializer) init(res *resource.Resource, settings component.TelemetrySettings, cfg telemetry.Config, asyncErrorChannel chan error, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader, useExternalMetricsServer bool) error {
+	if cfg.Metrics.Level == configtelemetry.LevelNone || (!useExternalMetricsServer && cfg.Metrics.Address == "") {
 		settings.Logger.Info(
 			"Skipping telemetry setup.",
 			zap.String(zapKeyTelemetryAddress, cfg.Metrics.Address),
@@ -109,10 +109,10 @@ func (tel *telemetryInitializer) init(res *resource.Resource, settings component
 		return err
 	}
 
-	return tel.initPrometheus(res, settings.Logger, cfg.Metrics.Address, cfg.Metrics.Level, asyncErrorChannel, otelMetricViews, otelMetricReader)
+	return tel.initPrometheus(res, settings.Logger, cfg.Metrics.Address, cfg.Metrics.Level, asyncErrorChannel, otelMetricViews, otelMetricReader, useExternalMetricsServer)
 }
 
-func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, logger *zap.Logger, address string, level configtelemetry.Level, asyncErrorChannel chan error, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader) error {
+func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, logger *zap.Logger, address string, level configtelemetry.Level, asyncErrorChannel chan error, otelMetricViews []sdkmetric.View, otelMetricReader sdkmetric.Reader, useExternalMetricsServer bool) error {
 	promRegistry := prometheus.NewRegistry()
 	if tel.useOtel {
 		if err := tel.initOpenTelemetry(res, promRegistry, otelMetricViews, otelMetricReader); err != nil {
@@ -124,24 +124,32 @@ func (tel *telemetryInitializer) initPrometheus(res *resource.Resource, logger *
 		}
 	}
 
-	logger.Info(
-		"Serving Prometheus metrics",
-		zap.String(zapKeyTelemetryAddress, address),
-		zap.String(zapKeyTelemetryLevel, level.String()),
-	)
-
-	mux := http.NewServeMux()
-	mux.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
-	server := &http.Server{
-		Addr:    address,
-		Handler: mux,
-	}
-	tel.servers = append(tel.servers, server)
-	go func() {
-		if serveErr := server.ListenAndServe(); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
-			asyncErrorChannel <- serveErr
+	if useExternalMetricsServer {
+		if address != "" {
+			logger.Sugar().Infof(
+				"Using an external metrics server - Prometheus metrics may not be served on %q", address,
+			)
 		}
-	}()
+	} else {
+		logger.Info(
+			"Serving Prometheus metrics",
+			zap.String(zapKeyTelemetryAddress, address),
+			zap.String(zapKeyTelemetryLevel, level.String()),
+		)
+
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.HandlerFor(promRegistry, promhttp.HandlerOpts{}))
+		server := &http.Server{
+			Addr:    address,
+			Handler: mux,
+		}
+		tel.servers = append(tel.servers, server)
+		go func() {
+			if serveErr := server.ListenAndServe(); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+				asyncErrorChannel <- serveErr
+			}
+		}()
+	}
 	return nil
 }
 

--- a/service/telemetry/telemetry.go
+++ b/service/telemetry/telemetry.go
@@ -14,8 +14,9 @@ import (
 )
 
 type Telemetry struct {
-	logger         *zap.Logger
-	tracerProvider *sdktrace.TracerProvider
+	logger                 *zap.Logger
+	internalTracerProvider *sdktrace.TracerProvider
+	tracerProvider         trace.TracerProvider
 }
 
 func (t *Telemetry) TracerProvider() trace.TracerProvider {
@@ -28,9 +29,12 @@ func (t *Telemetry) Logger() *zap.Logger {
 
 func (t *Telemetry) Shutdown(ctx context.Context) error {
 	// TODO: Sync logger.
-	return multierr.Combine(
-		t.tracerProvider.Shutdown(ctx),
-	)
+	if t.internalTracerProvider != nil {
+		return multierr.Combine(
+			t.internalTracerProvider.Shutdown(ctx),
+		)
+	}
+	return nil
 }
 
 // Settings holds configuration for building Telemetry.
@@ -39,18 +43,29 @@ type Settings struct {
 }
 
 // New creates a new Telemetry from Config.
-func New(_ context.Context, set Settings, cfg Config) (*Telemetry, error) {
+func New(_ context.Context, set Settings, cfg Config, tracerProvider trace.TracerProvider) (*Telemetry, error) {
 	logger, err := newLogger(cfg.Logs, set.ZapOptions)
 	if err != nil {
 		return nil, err
 	}
-	tp := sdktrace.NewTracerProvider(
-		// needed for supporting the zpages extension
-		sdktrace.WithSampler(alwaysRecord()),
-	)
+
+	var tp trace.TracerProvider
+	var internalTp *sdktrace.TracerProvider
+
+	if tracerProvider != nil {
+		tp = tracerProvider
+	} else {
+		internalTp = sdktrace.NewTracerProvider(
+			// needed for supporting the zpages extension
+			sdktrace.WithSampler(alwaysRecord()),
+		)
+		tp = internalTp
+	}
+
 	return &Telemetry{
-		logger:         logger,
-		tracerProvider: tp,
+		logger:                 logger,
+		internalTracerProvider: internalTp,
+		tracerProvider:         tp,
 	}, nil
 }
 


### PR DESCRIPTION
Grafana Agent uses code from the Collector. However, in order to integrate with it we need features which are not available in the Collector yet, hence the need for this forked repo. So far we dealt with this by exporting all Collector internals. This PR is an attempt at a more lightweight approach, where we only modify the minimum bits of functionality that we need.

There is also an upstream [PR](https://github.com/open-telemetry/opentelemetry-collector/pull/7696) to merge this functionality into the Collector itself, or at least to get some feedback on how appropriate this approach is.