### PR TITLE
Add an option to disable process metrics

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -65,6 +65,8 @@ type Settings struct {
 
 	UseExternalMetricsServer bool
 
+	DisableProcessMetrics bool
+
 	TracerProvider trace.TracerProvider
 
 	// For testing purpose only.
@@ -218,7 +220,7 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 		return fmt.Errorf("failed to build pipelines: %w", err)
 	}
 
-	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
+	if !set.DisableProcessMetrics && cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && (set.UseExternalMetricsServer || cfg.Telemetry.Metrics.Address != "") {
 		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
 		if err = proctelemetry.RegisterProcessMetrics(srv.telemetryInitializer.ocRegistry, srv.telemetryInitializer.mp, obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled(), getBallastSize(srv.host)); err != nil {
 			return fmt.Errorf("failed to register process metrics: %w", err)


### PR DESCRIPTION
This change allows the Agent to disable unnecessary metrics such as these:

```
# HELP traces_process_cpu_seconds_total Total CPU user and system time in seconds
# TYPE traces_process_cpu_seconds_total counter
traces_process_cpu_seconds_total{traces_config="firstConfig"} 1.5069131666666666
traces_process_cpu_seconds_total{traces_config="secondConfig"} 1.5074259166666666
# HELP traces_process_memory_rss Total physical memory (resident set size)
# TYPE traces_process_memory_rss gauge
traces_process_memory_rss{traces_config="firstConfig"} 1.37854976e+08
traces_process_memory_rss{traces_config="secondConfig"} 1.3787136e+08
# HELP traces_process_runtime_heap_alloc_bytes Bytes of allocated heap objects (see 'go doc runtime.MemStats.HeapAlloc')
# TYPE traces_process_runtime_heap_alloc_bytes gauge
traces_process_runtime_heap_alloc_bytes{traces_config="firstConfig"} 5.0238568e+07
traces_process_runtime_heap_alloc_bytes{traces_config="secondConfig"} 5.0247504e+07
# HELP traces_process_runtime_total_alloc_bytes_total Cumulative bytes allocated for heap objects (see 'go doc runtime.MemStats.TotalAlloc')
# TYPE traces_process_runtime_total_alloc_bytes_total counter
traces_process_runtime_total_alloc_bytes_total{traces_config="firstConfig"} 1.06180784e+08
traces_process_runtime_total_alloc_bytes_total{traces_config="secondConfig"} 1.0618972e+08
# HELP traces_process_runtime_total_sys_memory_bytes Total bytes of memory obtained from the OS (see 'go doc runtime.MemStats.Sys')
# TYPE traces_process_runtime_total_sys_memory_bytes gauge
traces_process_runtime_total_sys_memory_bytes{traces_config="firstConfig"} 9.8521368e+07
traces_process_runtime_total_sys_memory_bytes{traces_config="secondConfig"} 9.8521368e+07
# HELP traces_process_uptime_total Uptime of the process
# TYPE traces_process_uptime_total counter
traces_process_uptime_total{traces_config="firstConfig"} 183.863024
traces_process_uptime_total{traces_config="secondConfig"} 183.860567
```

They are especially confusing and unnecessary when using more than one traces config, as in the example above.