### PR TITLE
0.85 wildum

### DIFF
--- a/otelcol/configprovider.go
+++ b/otelcol/configprovider.go
@@ -100,7 +100,7 @@ func (cm *configProvider) Get(ctx context.Context, factories Factories) (*Config
 	}
 
 	var cfg *configSettings
-	if cfg, err = unmarshal(conf, factories); err != nil {
+	if cfg, err = Unmarshal(conf, factories); err != nil {
 		return nil, fmt.Errorf("cannot unmarshal the configuration: %w", err)
 	}
 

--- a/otelcol/configprovider_test.go
+++ b/otelcol/configprovider_test.go
@@ -28,7 +28,7 @@ func newConfig(yamlBytes []byte, factories Factories) (*Config, error) {
 
 	conf := confmap.NewFromStringMap(stringMap)
 
-	cfg, err := unmarshal(conf, factories)
+	cfg, err := Unmarshal(conf, factories)
 	if err != nil {
 		return nil, err
 	}

--- a/otelcol/unmarshaler.go
+++ b/otelcol/unmarshaler.go
@@ -29,7 +29,7 @@ type configSettings struct {
 
 // unmarshal the configSettings from a confmap.Conf.
 // After the config is unmarshalled, `Validate()` must be called to validate.
-func unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
+func Unmarshal(v *confmap.Conf, factories Factories) (*configSettings, error) {
 	// Unmarshal top level sections and validate.
 	cfg := &configSettings{
 		Receivers:  configunmarshaler.NewConfigs(factories.Receivers),

--- a/otelcol/unmarshaler_test.go
+++ b/otelcol/unmarshaler_test.go
@@ -20,7 +20,7 @@ func TestUnmarshalEmpty(t *testing.T) {
 	factories, err := nopFactories()
 	assert.NoError(t, err)
 
-	_, err = unmarshal(confmap.New(), factories)
+	_, err = Unmarshal(confmap.New(), factories)
 	assert.NoError(t, err)
 }
 
@@ -36,7 +36,7 @@ func TestUnmarshalEmptyAllSections(t *testing.T) {
 		"extensions": nil,
 		"service":    nil,
 	})
-	cfg, err := unmarshal(conf, factories)
+	cfg, err := Unmarshal(conf, factories)
 	assert.NoError(t, err)
 
 	zapProdCfg := zap.NewProductionConfig()
@@ -63,7 +63,7 @@ func TestUnmarshalUnknownTopLevel(t *testing.T) {
 	conf := confmap.NewFromStringMap(map[string]any{
 		"unknown_section": nil,
 	})
-	_, err = unmarshal(conf, factories)
+	_, err = Unmarshal(conf, factories)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "'' has invalid keys: unknown_section")
 }

--- a/service/service.go
+++ b/service/service.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/sdk/resource"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -30,6 +31,7 @@ import (
 	"go.opentelemetry.io/collector/service/internal/graph"
 	"go.opentelemetry.io/collector/service/internal/proctelemetry"
 	"go.opentelemetry.io/collector/service/telemetry"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
 
 // Settings holds configuration for building a new service.
@@ -60,6 +62,16 @@ type Settings struct {
 
 	// LoggingOptions provides a way to change behavior of zap logging.
 	LoggingOptions []zap.Option
+
+	OtelMetricViews []sdkmetric.View
+
+	OtelMetricReader sdkmetric.Reader
+
+	UseExternalMetricsServer bool
+
+	DisableProcessMetrics bool
+
+	TracerProvider trace.TracerProvider
 
 	// For testing purpose only.
 	useOtel *bool
@@ -97,7 +109,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		collectorConf:        set.CollectorConf,
 	}
 	var err error
-	srv.telemetry, err = telemetry.New(ctx, telemetry.Settings{ZapOptions: set.LoggingOptions}, cfg.Telemetry)
+	srv.telemetry, err = telemetry.New(ctx, telemetry.Settings{ZapOptions: set.LoggingOptions}, cfg.Telemetry, set.TracerProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get logger: %w", err)
 	}
@@ -114,7 +126,7 @@ func New(ctx context.Context, set Settings, cfg Config) (*Service, error) {
 		Resource: pcommonRes,
 	}
 
-	if err = srv.telemetryInitializer.init(res, srv.telemetrySettings, cfg.Telemetry, set.AsyncErrorChannel); err != nil {
+	if err = srv.telemetryInitializer.init(res, srv.telemetrySettings, cfg.Telemetry, set.AsyncErrorChannel, set.OtelMetricViews, set.OtelMetricReader, set.UseExternalMetricsServer); err != nil {
 		return nil, fmt.Errorf("failed to initialize telemetry: %w", err)
 	}
 	srv.telemetrySettings.MeterProvider = srv.telemetryInitializer.mp
@@ -167,6 +179,9 @@ func (srv *Service) Shutdown(ctx context.Context) error {
 	var errs error
 
 	// Begin shutdown sequence.
+	if srv.telemetrySettings.Logger == nil {
+		return fmt.Errorf("no logger has been initialised")
+	}
 	srv.telemetrySettings.Logger.Info("Starting shutdown...")
 
 	if err := srv.host.serviceExtensions.NotifyPipelineNotReady(); err != nil {
@@ -218,7 +233,7 @@ func (srv *Service) initExtensionsAndPipeline(ctx context.Context, set Settings,
 		return fmt.Errorf("failed to build pipelines: %w", err)
 	}
 
-	if cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && cfg.Telemetry.Metrics.Address != "" {
+	if !set.DisableProcessMetrics && cfg.Telemetry.Metrics.Level != configtelemetry.LevelNone && (set.UseExternalMetricsServer || cfg.Telemetry.Metrics.Address != "") {
 		// The process telemetry initialization requires the ballast size, which is available after the extensions are initialized.
 		if err = proctelemetry.RegisterProcessMetrics(srv.telemetryInitializer.ocRegistry, srv.telemetryInitializer.mp, obsreportconfig.UseOtelForInternalMetricsfeatureGate.IsEnabled(), getBallastSize(srv.host)); err != nil {
 			return fmt.Errorf("failed to register process metrics: %w", err)

--- a/service/service.go
+++ b/service/service.go
@@ -180,7 +180,7 @@ func (srv *Service) Shutdown(ctx context.Context) error {
 
 	// Begin shutdown sequence.
 	if srv.telemetrySettings.Logger == nil {
-		return fmt.Errorf("no logger has been initialised")
+		return fmt.Errorf("no logger has been initialized")
 	}
 	srv.telemetrySettings.Logger.Info("Starting shutdown...")
 

--- a/service/telemetry.go
+++ b/service/telemetry.go
@@ -124,7 +124,7 @@ func (tel *telemetryInitializer) initMetrics(res *resource.Resource, logger *zap
 
 	if useExternalMetricsServer {
 		if len(cfg.Metrics.Address) != 0 || len(cfg.Metrics.Readers) != 0 {
-			logger.Sugar().Infof(
+			logger.Sugar().Debugf(
 				"Using an external metrics server - Prometheus metrics may not be served on %q or %q", cfg.Metrics.Address, cfg.Metrics.Readers,
 			)
 		}

--- a/service/telemetry_test.go
+++ b/service/telemetry_test.go
@@ -276,7 +276,7 @@ func TestTelemetryInit(t *testing.T) {
 				Logger:   zap.NewNop(),
 				Resource: res,
 			}
-			err := tel.init(otelRes, settings, *tc.cfg, make(chan error))
+			err := tel.init(otelRes, settings, *tc.cfg, make(chan error), nil, nil, false)
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, tel.shutdown())


### PR DESCRIPTION
**Description:** This patch disables the Collector's metric endpoint and adds the Collector's metrics to the Agent metrics endpoint.

The patch is an adaptation of the patch that was made for 0.80: https://github.com/open-telemetry/opentelemetry-collector/compare/main...grafana:opentelemetry-collector:0.80-grafana

**Link to tracking Issue:** https://github.com/grafana/agent/issues/5218

**Testing:** it was tested with the agent while running the configs found in this file: https://github.com/grafana/agent/pull/4343/files
